### PR TITLE
Fix #15: plugin working on initial download & enable

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -16,8 +16,23 @@ export const DEFAULT_SETTINGS: TaboutSettings = {
             jumpAfter: true,  
         },
         {
+            tokenMatcher: "formatting_formatting-quote_formatting-quote-1_hmd-callout",
+            lookups: ['"', "'", ")", "}"],
+            jumpAfter: true,  
+        },
+        {
+            tokenMatcher: "quote",
+            lookups: ['"', "'", ")", "}"],
+            jumpAfter: true,  
+        },
+        {
             tokenMatcher: "hmd-internal-link",
             lookups: ["]"],
+            jumpAfter: true,
+        },
+        {
+            tokenMatcher: "formatting-link_formatting-link-start",
+            lookups: ["]]"],
             jumpAfter: true,
         },
         {
@@ -27,7 +42,7 @@ export const DEFAULT_SETTINGS: TaboutSettings = {
         },
         {
             tokenMatcher: "em",
-            lookups: ["*"],
+            lookups: ["*", "_"],
             jumpAfter: true,
         },
         {
@@ -40,5 +55,30 @@ export const DEFAULT_SETTINGS: TaboutSettings = {
             lookups: ["`"],
             jumpAfter: true,
         },
+        {
+            tokenMatcher: "header_header",
+            lookups: ['"', "'", ")", "}", "]"],
+            jumpAfter: true,
+        },
+        {
+            tokenMatcher: "list-1",
+            lookups: ['"', "'", ")", "}", "]"],
+            jumpAfter: true,
+        },
+        {
+            tokenMatcher: "list-2",
+            lookups: ['"', "'", ")", "}", "]"],
+            jumpAfter: true,
+        },
+        {
+            tokenMatcher: "list-3",
+            lookups: ['"', "'", ")", "}", "]"],
+            jumpAfter: true,
+        },
+        {
+            tokenMatcher: "hmd-codeblock",
+            lookups: [")", "}"],
+            jumpAfter: true,
+        }        
     ],
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,8 +11,13 @@ export interface Rule {
 export const DEFAULT_SETTINGS: TaboutSettings = {
     rules: [
         {
+            tokenMatcher: "Document",
+            lookups: ['"', "'", ")", "}"],
+            jumpAfter: true,  
+        },
+        {
             tokenMatcher: "hmd-internal-link",
-            lookups: ["]]"],
+            lookups: ["]"],
             jumpAfter: true,
         },
         {
@@ -26,14 +31,14 @@ export const DEFAULT_SETTINGS: TaboutSettings = {
             jumpAfter: true,
         },
         {
+            tokenMatcher: "math",
+            lookups: ["$"],
+            jumpAfter: true,
+        },
+        {
             tokenMatcher: "code",
             lookups: ["`"],
             jumpAfter: true,
         },
-        {
-            tokenMatcher: "math",
-            lookups: ["{", "("],
-            jumpAfter: true,
-        }
     ],
 }


### PR DESCRIPTION
This pull request fixes #15,

Problem description:

On initial download, tabout would not work with Document styled characters: ", ', ), }. And the manual fix to this was binding: 
![image](https://github.com/phibr0/obsidian-tabout/assets/117041405/288e4e20-eab0-43d5-94d3-80c63b63b986)
and manually having to add placeholders between the unsupported characters and adding those tabout characters for the Document environment. 

I only was able to figure this out after some manual testing and help from @vishae:
> When I first installed the plugin, I also noticed that none of the pre-existing rules worked.
> 
> But try the following steps:
> 
> 1. Type **placeholder** into your document
> 2. Put the cursor somewhere within the word "placeholder"
> 3. Run the command “Add Rule for this Environment”.
> 4. Type "**" in the "Characters" field.
> 5. Click "Add this Rule"
> 
> You will find that tabout now works with the ** ** environment. Repeat that with all the other environments you want to tabout of (eg. [], [[]], **strong**, _em_)
> 
> **Note:** Always type some words between the open and closing characters otherwise tabout might use the wrong environment.

So, I went ahead and tested the changes I made to the type.ts file so that the majority of Obsidian users who downloaded this plugin would be able to use it right off the bat for more common use-cases, without needing to look at the Github Issues Page for workarounds.


